### PR TITLE
Update payment completion endpoint

### DIFF
--- a/FLOWS.md
+++ b/FLOWS.md
@@ -170,7 +170,7 @@ const onReadyForServerCompletion = (paymentId: string, txid: string) => {
 };
 ```
 
-On the backend side of your app make an API call to Pi Platform `POST /payments/:paymentId/approve` to let Pi Servers know that payment has been completed.
+On the backend side of your app make an API call to Pi Platform `POST /payments/:paymentId/complete` to let Pi Servers know that payment has been completed.
 
 ```typescript
 // backend/src/index.ts


### PR DESCRIPTION
## Summary
- reference the correct Pi API endpoint for completing payments

## Testing
- `CI=true npm test --prefix frontend --silent -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6865dd1661e4832b8bca50d308d12970