### PR TITLE
Add Jest setup and Header component tests

### DIFF
--- a/frontend/src/Shop/components/__tests__/Header.test.tsx
+++ b/frontend/src/Shop/components/__tests__/Header.test.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Header from '../Header';
+import { User } from '../../';
+
+describe('Header component', () => {
+  test('shows Sign in button when no user', () => {
+    render(<Header user={null} onSignIn={() => {}} onSignOut={() => {}} />);
+    expect(screen.getByText(/sign in/i)).toBeInTheDocument();
+  });
+
+  test('shows Sign out button when user present', () => {
+    const user: User = { uid: '1', username: 'tester' };
+    render(<Header user={user} onSignIn={() => {}} onSignOut={() => {}} />);
+    expect(screen.getByText(/sign out/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/setupTests.ts
+++ b/frontend/src/setupTests.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';


### PR DESCRIPTION
## Summary
- configure test setup importing `@testing-library/jest-dom`
- add basic tests for the Header component

## Testing
- `yarn test --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6865dd1890ec832b92e7f6aeaabf42ab