### PR TITLE
Fix typo in deployment documentation

### DIFF
--- a/doc/deployment.md
+++ b/doc/deployment.md
@@ -87,7 +87,7 @@ This will bring you to the App Dashboard, from this screen you can continue the 
 
 ### 4. Set up environment variables (1/3)
 
-Create a .env config file in order to enable docker-compose to pick up your environmnent variables:
+Create a .env config file in order to enable docker-compose to pick up your environment variables:
 
 ```shell
 # Move to the app's directory:


### PR DESCRIPTION
## Summary
- fix typo in deployment guide

## Testing
- `npm test --prefix frontend --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865dd13e220832b956f42a2ca45c4e4